### PR TITLE
Fix static typing checks

### DIFF
--- a/tools/merge_csv.py
+++ b/tools/merge_csv.py
@@ -29,6 +29,14 @@ def load_csv(filename: str):
         csvreader = csv.DictReader(file)
         return [data.DeviceCarbonFootprint.from_text(clean_device(row)) for row in csvreader]
 
+def get_key(device: dict, key_name: str) -> str:
+    assert key_name in device
+    if key_name == 'sources':
+        pdf_file = re.search(r'([^\/]*\.pdf)', device.get(key_name, ""))
+        assert pdf_file is not None
+        return pdf_file[0]
+    return device.get(key_name, "").lower()
+
 def main(string_args: Optional[List[str]] = None) -> None:
     argparser = argparse.ArgumentParser(
         description='Merge two Boavizta csv file',
@@ -50,15 +58,10 @@ def main(string_args: Optional[List[str]] = None) -> None:
     nb_duplicates = [0]*nb_files
     conflict_count :Dict[str,int] = {}
 
-    key_name = args.key
-    get_key = lambda d: d.get(key_name).lower()
-    if key_name=='sources':
-        get_key = lambda d: re.search(r'([^\/]*\.pdf)', d.get(key_name))[0]
-
     for i in reversed(range(nb_files)):
         devices = load_csv(args.files[i])
         for device in reversed(devices):
-            key = get_key(device)
+            key = get_key(device, args.key)
             if key in result:
                 # merge the twos while giving priority to the one that is already present in result
                 device2 = result[key]

--- a/tools/monitoring/clean_database.py
+++ b/tools/monitoring/clean_database.py
@@ -21,7 +21,7 @@ def main(string_args: Optional[List[str]] = None) -> None:
     content = data.DeviceCarbonFootprint.csv_headers()
     with open(args.file, 'rt', encoding='utf-8') as existing_file:
         csvfile = csv.DictReader(existing_file)
-        seen = []
+        seen: List[data.DeviceCarbonFootprint] = []
         for row in csvfile:
             result=data.DeviceCarbonFootprint(row)
             if not 'comment' in result.data:

--- a/tools/parsers/dell_laptop.py
+++ b/tools/parsers/dell_laptop.py
@@ -5,7 +5,7 @@ See an example here https://i.dell.com/sites/csdocuments/CorpComm_Docs/en/carbon
 import logging
 import re
 import datetime
-from typing import BinaryIO, Iterator
+from typing import BinaryIO, Iterator, Dict, Any
 
 from tools.parsers.lib import data
 from tools.parsers.lib.image import crop, find_text_in_image, image_to_text
@@ -108,7 +108,7 @@ def parse(body: BinaryIO, pdf_filename: str) -> Iterator[data.DeviceCarbonFootpr
     if not 'gwp_use_ratio' in extracted:
         unpie = piechart_analyser.PiechartAnalyzer(debug=0)
 
-        pie_data = {}
+        pie_data: Dict[str, Any] = {}
         for image in pdf.list_images(body):
             unpie_output = unpie.analyze(image, ocrprofile='DELL')
             if unpie_output and len(unpie_output.keys()) > len(pie_data.keys()):

--- a/tools/parsers/hp_workplace.py
+++ b/tools/parsers/hp_workplace.py
@@ -6,7 +6,7 @@ See an example here https://h22235.www2.hp.com/hpinfo/globalcitizenship/environm
 import logging
 import re
 import datetime
-from typing import BinaryIO, Iterator
+from typing import BinaryIO, Iterator, Dict, Any
 import hashlib
 import math
 
@@ -180,7 +180,7 @@ def parse(body: BinaryIO, pdf_filename: str) -> Iterator[data.DeviceCarbonFootpr
     if not 'gwp_use_ratio' in extracted:
         unpie = piechart_analyser.PiechartAnalyzer(debug=0)
 
-        pie_data = {}
+        pie_data: Dict[str, Any] = {}
         for image in pdf.list_images(body):
             md5 = hashlib.md5(image).hexdigest()
             if (md5 == 'aa44d95aad83a5871bd7974cafd63a06'):

--- a/tools/parsers/lenovo.py
+++ b/tools/parsers/lenovo.py
@@ -6,7 +6,7 @@ See an example here https://static.lenovo.com/ww/docs/regulatory/eco-declaration
 import logging
 import re
 import datetime
-from typing import BinaryIO, Iterator
+from typing import BinaryIO, Iterator, Dict, Any
 
 from tools.parsers.lib import data
 from tools.parsers.lib import loader
@@ -77,7 +77,7 @@ def parse(body: BinaryIO, pdf_filename: str) -> Iterator[data.DeviceCarbonFootpr
     if not 'gwp_use_ratio' in extracted:
         unpie = piechart_analyser.PiechartAnalyzer(debug=0)
 
-        pie_data = {}
+        pie_data: Dict[str, Any] = {}
         for image in pdf.list_images(body):
             unpie_output = unpie.analyze(image, ocrprofile='Lenovo')
             if unpie_output and len(unpie_output.keys()) > len(pie_data.keys()):

--- a/tools/parsers/lib/data.py
+++ b/tools/parsers/lib/data.py
@@ -136,9 +136,9 @@ class DeviceCarbonFootprint:
         typed_data: DeviceCarbonFootprintData = {}
         for key in DeviceCarbonFootprintData.__annotations__.keys():
             if isstring(self.get(key)):
-                typed_data[key]=cast(str, self.get(key)).replace(",","").replace("\"","").replace(";","").strip()
+                typed_data[key]=cast(str, self.get(key)).replace(",","").replace("\"","").replace(";","").strip()  # type: ignore [misc]
             else:
-                typed_data[key]=self.get(key)
+                typed_data[key]=self.get(key)  # type: ignore [misc]
         return DeviceCarbonFootprint(typed_data)
 
     def as_csv_row(self, csv_format: Literal['us', 'fr'] = 'us') -> str:
@@ -162,23 +162,23 @@ class DeviceCarbonFootprint:
             v1 = device1.get(key)
             v2 = device2.get(key)
             if not is_empty(v1) and is_empty(v2):
-                result[key]=v1
+                result[key]=v1  # type: ignore [misc]
                 report[0].add(key)
             elif is_empty(v1) and not is_empty(v2):
-                result[key]=v2
+                result[key]=v2  # type: ignore [misc]
                 report[1].add(key)
             elif is_empty(v1) and is_empty(v2) or are_equal(v1,v2):
-                result[key]=v2
+                result[key]=v2  # type: ignore [misc]
                 report[1].add(key)
             elif are_close_enough(v1,v2):
                 if verbose:
                     print("WARNING, in merge,", key, ":", v1, "and", v2, "are considered close enough ->", v2)
-                result[key]=v2
+                result[key]=v2  # type: ignore [misc]
                 report[1].add(key)
             elif key in ignore_keys:
                 if verbose>1:
                     print("WARNING, in merge, ignore difference in field", key, ":", v1, "<->", v2)
-                result[key]=v2
+                result[key]=v2  # type: ignore [misc]
                 report[1].add(key)
             elif key=='sources':
                 file1:str
@@ -192,7 +192,7 @@ class DeviceCarbonFootprint:
                     print("WARNING, in merge source urls are different:")
                     print("  ignored: ", v1)
                     print("  retained:", v2)
-                result[key]=v2
+                result[key]=v2  # type: ignore [misc]
                 report[1].add(key)
             else:
                 conflicts.append(key)
@@ -210,10 +210,10 @@ class DeviceCarbonFootprint:
                     k = input()
             if k=='o':
                 for key in conflicts:
-                    result[key] = device1.get(key)
+                    result[key] = device1.get(key)  # type: ignore [misc]
                     report[0].add(key)
             else:
                 for key in conflicts:
-                    result[key] = device2.get(key)
+                    result[key] = device2.get(key)  # type: ignore [misc]
                     report[1].add(key)
         return DeviceCarbonFootprint(result), report, conflicts

--- a/tools/parsers/lib/data.py
+++ b/tools/parsers/lib/data.py
@@ -4,7 +4,7 @@ import hashlib
 import math
 import re
 from sre_compile import isstring
-from typing import Any, Dict, Iterable, Iterator, Literal, Union, TextIO, TypedDict, Tuple, List, Set
+from typing import Any, Dict, Iterable, Iterator, Literal, Union, TextIO, TypedDict, Tuple, List, Set, cast
 
 class DeviceCarbonFootprintData(TypedDict, total=False):
     """The carbon footprint data for one device model."""
@@ -136,7 +136,7 @@ class DeviceCarbonFootprint:
         typed_data: DeviceCarbonFootprintData = {}
         for key in DeviceCarbonFootprintData.__annotations__.keys():
             if isstring(self.get(key)):
-                typed_data[key]=self.get(key).replace(",","").replace("\"","").replace(";","").strip()
+                typed_data[key]=cast(str, self.get(key)).replace(",","").replace("\"","").replace(";","").strip()
             else:
                 typed_data[key]=self.get(key)
         return DeviceCarbonFootprint(typed_data)

--- a/tools/parsers/lib/data.py
+++ b/tools/parsers/lib/data.py
@@ -156,7 +156,7 @@ class DeviceCarbonFootprint:
         result: DeviceCarbonFootprintData = {}
         ignore_keys = ['added_date', 'add_method','comment']
         # gather attributes coming from device1 and device2
-        report = [set(),set()]
+        report: List[set] = [set(),set()]
         conflicts = []
         for key in DeviceCarbonFootprintData.__annotations__.keys():
             v1 = device1.get(key)

--- a/tools/parsers/lib/data.py
+++ b/tools/parsers/lib/data.py
@@ -184,8 +184,8 @@ class DeviceCarbonFootprint:
                 file1:str
                 file2:str
                 try:
-                    file1=re.search(r'([^\/]*\.pdf)', str(v1))[0]
-                    file2=re.search(r'([^\/]*\.pdf)', str(v2))[0]
+                    file1=re.search(r'([^\/]*\.pdf)', str(v1))[0]  # type: ignore [index]
+                    file2=re.search(r'([^\/]*\.pdf)', str(v2))[0]  # type: ignore [index]
                 except:
                     file1,file2='1','2'
                 if verbose>1 or (verbose and file1!=file2):

--- a/tools/parsers/lib/data.py
+++ b/tools/parsers/lib/data.py
@@ -184,8 +184,8 @@ class DeviceCarbonFootprint:
                 file1:str
                 file2:str
                 try:
-                    file1=re.search(r'([^\/]*\.pdf)', v1)[0]
-                    file2=re.search(r'([^\/]*\.pdf)', v2)[0]
+                    file1=re.search(r'([^\/]*\.pdf)', str(v1))[0]
+                    file2=re.search(r'([^\/]*\.pdf)', str(v2))[0]
                 except:
                     file1,file2='1','2'
                 if verbose>1 or (verbose and file1!=file2):

--- a/tools/tests/requirements.txt
+++ b/tools/tests/requirements.txt
@@ -1,1 +1,2 @@
 mypy==0.910
+types-requests==2.28.11.2


### PR DESCRIPTION
In order to make the CI green again :sweat_smile: this PR fix all the type hint errors reported by `mypy` on the [CI workflow](https://github.com/Boavizta/environmental-footprint-data/blob/00640fbbafb3f1b1fc1e0ed3d32f29c7e8471278/.github/workflows/main.yml).
```console
$ mypy --ignore-missing-imports
Found 24 errors in 6 files (checked 38 source files)
```

Maybe could be a good idea to add a branch protection rule to only allow/enforce merges on the main branch if CI checks are green, to avoid re-doing this work in a future. I don't know all the history behind the project/repo and the reasons to adopt static typing but it could require some additional when importing code from another code base.

Please, don't hesitate to suggest any changes or to reject this PR if it's not relevant/useful.